### PR TITLE
findIntersections from  O(N^2) to O(N) time

### DIFF
--- a/src/intersections.jl
+++ b/src/intersections.jl
@@ -6,39 +6,36 @@
 
 ### Generate a list of intersections ###
 function findIntersections(highways::Dict{Int,Highway})
-    intersections = Dict{Int,Intersection}()
-    crossings = Int[]
     seen = Set{Int}()
+    intersections = Dict{Int,Intersection}()
 
-    # Highway ends
-    for (k, highway_k) in highways
-        n_nodes = length(highway_k.nodes)
-        for i in 1:max(1, n_nodes - 1):n_nodes
-            node = highway_k.nodes[i]
-            hwys = get!(Intersection, intersections, node).highways
-            push!(hwys, k)
-        end
-    end
+    for hwy in values(highways)
+        n_nodes = length(hwy.nodes)
 
-    # Highway crossings
-    for (i, highway_i) in highways
-        for j in keys(highways)
-            if i > j
-                for node in intersect(highway_i.nodes, highways[j].nodes)
+        for i in 1:n_nodes
+            node = hwy.nodes[i]
 
-                    hwys = get!(Intersection, intersections, node).highways
-                    push!(hwys, i, j)
-
-                    if !in(node, seen)
-                        push!(seen, node)
-                        push!(crossings, node)
-                    end
-                end
+            if i == 1 || i == n_nodes || in(node, seen)
+                get!(Intersection, intersections, node)
+            else
+                push!(seen, node)
             end
         end
     end
 
-    return intersections, crossings
+    for (hwy_key, hwy) in highways
+        n_nodes = length(hwy.nodes)
+
+        for i in 1:n_nodes
+            node = hwy.nodes[i]
+
+            if i == 1 || i == n_nodes || haskey(intersections, node)
+                push!(intersections[node].highways, hwy_key)
+            end
+        end
+    end
+
+    return intersections
 end
 
 ### Generate a new list of highways divided up by intersections

--- a/test/routes.jl
+++ b/test/routes.jl
@@ -76,7 +76,7 @@ end
 @test edges[50].source.index == 22
 
 # Form transportation network from segments
-intersections, crossings = findIntersections(hwys)
+intersections = findIntersections(hwys)
 segments = segmentHighways(nodesENU, hwys, intersections, roads, Set(1:8))
 segment_network = createGraph(segments, intersections)
 


### PR DESCRIPTION
e.g. for 40k highways, cut time from 21 minutes to 0.18 seconds.

Also only returns 'intersections', no 'crossings', which was
never documented or used anywhere, wasn't quite right, and would add
overhead to the new, lean version.
