### PR TITLE
Intersection clustering

### DIFF
--- a/docs/data.rst
+++ b/docs/data.rst
@@ -36,16 +36,18 @@ The only required input is the highway dictionary returned by "getOSMData()." A
 dictionary of "Intersection" types is returned, intexed by the node ID of the
 intersection.
 
-In some cases, such as boulevards and other divided roads, OpenStreetMap represents a street as two one-way highways.  This can result in multiple "intersections" detected per true intersection. If desired, these intersections can be "clustered," replacing these multiple intersection-lets with a single node. To do this, we must first cluster the highways, by gathering all highways with a common name (note that this is dependent on the quality of street name tags in your source data). 
-We then search for proximal instances of these highway sets crossing one another. Flag max_dist can be used to change the required proximity of the nodes to be considered an intersection (the default is 15 meters). Note that this proximity is the maximum distance the node can be from the centroid of all nodes in the intersection at the time the node is added.
+In some cases, such as boulevards and other divided roads, OpenStreetMap represents a street as two one-way highways.  This can result in multiple "intersections" detected per true intersection. If desired, these intersections can be "clustered," replacing these multiple intersection-lets with a single node. This gives a better estimate of the total number of highway intersections in a region. 
+
+To do this, we first "cluster" the highways, by gathering all highways with a common name (note that this is dependent on the quality of street name tags in your source data).  We then search for proximal instances of these highway sets crossing one another. Flag max_dist can be used to change the required proximity of the nodes to be considered an intersection (the default is 15 meters). Note that this proximity is the maximum distance the node can be from the centroid of all nodes in the intersection at the time the node is added. If an intersection involves the same highways as an existing cluster during the search but is further away than max_dist, a new cluster will be formed, initialized at that point.
 
 The code to accomplish this is as follows:
 
 .. code-block:: python 
 
     highway_sets = findHighwaySets(highways)
-    intersection_mapping, intersection_nodes = findIntersectionClusters(nodes,intersections,highway_sets,max_dist=15)
+    intersection_mapping = findIntersectionClusters(nodes,intersections,highway_sets,max_dist=15)
     replaceHighwayNodes!(highways,intersection_mapping)
+    cluster_node_ids = unique(collect(values(intersection_mapping)))
 
 The optional flag "max_dist" is in the units of your "nodes" object. 
 

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -36,6 +36,20 @@ The only required input is the highway dictionary returned by "getOSMData()." A
 dictionary of "Intersection" types is returned, intexed by the node ID of the
 intersection.
 
+In some cases, such as boulevards and other divided roads, OpenStreetMap represents a street as two one-way highways.  This can result in multiple "intersections" detected per true intersection. If desired, these intersections can be "clustered," replacing these multiple intersection-lets with a single node. To do this, we must first cluster the highways, by gathering all highways with a common name (note that this is dependent on the quality of street name tags in your source data). 
+We then search for proximal instances of these highway sets crossing one another. Flag max_dist can be used to change the required proximity of the nodes to be considered an intersection (the default is 15 meters). Note that this proximity is the maximum distance the node can be from the centroid of all nodes in the intersection at the time the node is added.
+
+The code to accomplish this is as follows:
+
+.. code-block:: python 
+
+    highway_sets = findHighwaySets(highways)
+    intersection_mapping, intersection_nodes = findIntersectionClusters(nodes,intersections,highway_sets,max_dist=15)
+    replaceHighwayNodes!(highways,intersection_mapping)
+
+The optional flag "max_dist" is in the units of your "nodes" object. 
+
+
 Working with Segments
 ---------------------
 

--- a/src/OpenStreetMap.jl
+++ b/src/OpenStreetMap.jl
@@ -19,6 +19,7 @@ export lla2enu, lla2ecef, ecef2lla, ecef2enu
 export roadways, walkways, cycleways, classify
 export createGraph, shortestRoute, fastestRoute, distance, routeEdges
 export nodesWithinRange, nodesWithinDrivingDistance, nodesWithinDrivingTime
+export findHighwaySets, findIntersectionClusters, replaceHighwayNodes!
 export simCityGrid
 
 include("types.jl")

--- a/src/highways.jl
+++ b/src/highways.jl
@@ -53,9 +53,9 @@ function cycleways(highways::Dict{Int,Highway})
     return cycles
 end
 
-### Find Highway Pairs (two one-way highways with same name) ###
-function findHighwayPairs( highways::Dict{Int,Highway} )
-    clusters = HighwayCluster[]
+### Find sets of same-named highways ###
+function findHighwaySets( highways::Dict{Int,Highway} )
+    clusters = HighwaySet[]
 
     street_names = (String,String,Int)[]
     
@@ -84,7 +84,7 @@ function findHighwayPairs( highways::Dict{Int,Highway} )
         end
         
         if length(cluster) > 1
-            push!(clusters,HighwayCluster(Set(cluster)))
+            push!(clusters,HighwaySet(Set(cluster)))
         end
     end
 

--- a/src/highways.jl
+++ b/src/highways.jl
@@ -52,3 +52,43 @@ function cycleways(highways::Dict{Int,Highway})
 
     return cycles
 end
+
+### Find Highway Pairs (two one-way highways with same name) ###
+function findHighwayPairs( highways::Dict{Int,Highway} )
+    clusters = HighwayCluster[]
+
+    street_names = (String,String,Int)[]
+    
+    for (key, highway) in highways
+        if length(highway.name) > 0 && highway.oneway
+            push!(street_names,(highway.name,highway.class,key))
+        end
+    end
+
+    sort!(street_names)
+    for k = 2:length(street_names)
+        cluster = Int[]
+        for kk = 1:(k-1)
+            if k == length(street_names) || street_names[k][1] != street_names[k+1][1]
+                if street_names[k][1] == street_names[k-kk][1]
+                    if street_names[k][2] == street_names[k-kk][2]
+                        if kk == 1
+                            push!(cluster,street_names[k][3])
+                        end
+                        push!(cluster,street_names[k-kk][3])
+                    end
+                else
+                    break
+                end
+            end
+        end
+        
+        if length(cluster) > 1
+            push!(clusters,HighwayCluster(Set(cluster)))
+        end
+    end
+
+    return clusters
+end
+
+

--- a/src/intersections.jl
+++ b/src/intersections.jl
@@ -39,7 +39,7 @@ function findIntersections(highways::Dict{Int,Highway})
 end
 
 ### Generate a new list of highways divided up by intersections
-function segmentHighways(nodes, highways, intersections, classes, levels=Set(1:10))
+function segmentHighways(nodes, highways::Dict{Int,Highway}, intersections, classes, levels=Set(1:10))
     segments = Segment[]
     inters = Set(keys(intersections))
 
@@ -70,7 +70,7 @@ function segmentHighways(nodes, highways, intersections, classes, levels=Set(1:1
 end
 
 ### Generate a list of highways from segments, for plotting purposes
-function highwaySegments(segments::Vector{Segment})
+function highwaySegments( segments::Vector{Segment} )
     highways = Dict{Int,Highway}()
 
     for k = 1:length(segments)
@@ -82,7 +82,10 @@ end
 
 
 ### Cluster highway intersections into higher-level intersections ###
-function findIntersectionClusters(nodes, intersections_in, highway_clusters; max_dist=15.0)
+function findIntersectionClusters( nodes::Dict{Int,ENU}, 
+                                   intersections_in::Dict{Int,Intersection}, 
+                                   highway_clusters::Vector{HighwaySet}; 
+                                   max_dist=15.0 )
     hwy_cluster_mapping = Dict{Int,Int}()
     for k = 1:length(highway_clusters)
         hwys = [highway_clusters[k].highways...]
@@ -176,7 +179,7 @@ end
 
 
 ### Replace Nodes in Highways Using Node Remapping
-function replaceHighwayNodes!(highways::Dict{Int,Highway}, node_map::Dict{Int,Int})
+function replaceHighwayNodes!( highways::Dict{Int,Highway}, node_map::Dict{Int,Int} )
     for (key,hwy) in highways
         all_equal = true
         for k = 1:length(hwy.nodes)

--- a/src/intersections.jl
+++ b/src/intersections.jl
@@ -44,7 +44,7 @@ function segmentHighways(nodes, highways, intersections, classes, levels=Set(1:1
     inters = Set(keys(intersections))
 
     for (i, class) in classes
-        if in(class, levels)
+        if in(class, levels) && haskey(highways,i)
             highway = highways[i]
             first = 1
             for j = 2:length(highway.nodes)

--- a/src/intersections.jl
+++ b/src/intersections.jl
@@ -48,7 +48,7 @@ function segmentHighways(nodes, highways, intersections, classes, levels=Set(1:1
             highway = highways[i]
             first = 1
             for j = 2:length(highway.nodes)
-                if in(highway.nodes[j], inters) || j == length(highway.nodes)
+                if highway.nodes[first] != highway.nodes[j] && (in(highway.nodes[j], inters) || j == length(highway.nodes))
                     node0 = highway.nodes[first]
                     node1 = highway.nodes[j]
                     route_nodes = highway.nodes[first:j]
@@ -79,3 +79,119 @@ function highwaySegments(segments::Vector{Segment})
 
     return highways
 end
+
+
+### Cluster highway intersections into higher-level intersections ###
+function findIntersectionClusters(nodes, intersections_in, highway_clusters; max_dist=15.0)
+    clustered_highways = Int[]
+    hwy_cluster_mapping = Dict{Int,Int}()
+    for k = 1:length(highway_clusters)
+        push!(clustered_highways,highway_clusters[k].highways...)
+
+        hwys = [highway_clusters[k].highways...]
+        for kk = 1:length(hwys)
+            hwy_cluster_mapping[hwys[kk]] = k
+        end
+    end
+    clustered_highways = unique(clustered_highways)
+
+    # Deep copy intersections dictionary and replace highways with highway 
+    # clusters where available
+    intersections = deepcopy(intersections_in)
+    if true
+    for (node,inter) in intersections
+        hwys = [inter.highways...]
+        for k = 1:length(hwys)
+            if haskey(hwy_cluster_mapping,hwys[k])
+                hwys[k] = hwy_cluster_mapping[hwys[k]]
+            end
+        end
+        inter.highways = Set(hwys)
+    end
+    end
+
+    # Group intersections by number of streets contained
+    hwy_counts = Vector{Int}[]
+
+    for (node,inter) in intersections
+        hwy_cnt = length(inter.highways)
+        if hwy_cnt > length(hwy_counts)
+            for k = (length(hwy_counts)+1):hwy_cnt
+                push!(hwy_counts,Int[])
+            end
+        end
+
+        push!(hwy_counts[hwy_cnt], node)
+    end
+
+    cluster_mapping = Dict{Int,Int}()
+    clusters = Set{Int}[]
+    clusters_nodes = Set{Int}[]
+
+    for kk = 1:length(hwy_counts)
+        k = length(hwy_counts)+1-kk
+
+        for inter in hwy_counts[k]
+            found = false
+            for index = 1:length(clusters)
+                if issubset(intersections[inter].highways,clusters[index])
+                    # Check distance to cluster centroid
+                    c = centroid(nodes,[clusters_nodes[index]...])
+                    dist = distance(c,nodes[inter])
+                    if dist < max_dist
+                        cluster_mapping[inter] = index
+                        clusters_nodes[index] = Set([clusters_nodes[index]...,inter])
+                        found = true
+                        break
+                    end
+                end
+            end
+            if !found
+                push!(clusters,intersections[inter].highways)
+                push!(clusters_nodes,Set(inter))
+                cluster_mapping[inter] = length(clusters)
+            end
+        end
+    end
+
+    cluster_nodes = Int[]
+    cluster_map = Dict{Int,Int}()
+    for k = 1:length(clusters_nodes)
+        if length(clusters_nodes[k]) > 1
+            n = [clusters_nodes[k]...]
+            c = centroid(nodes,n)
+            push!(cluster_nodes,addNewNode(nodes,c))
+
+            for j = 1:length(n)
+                cluster_map[n[j]] = cluster_nodes[end]
+            end
+
+            if false
+                println("#####")
+                nds = [clusters_nodes[k]...]
+                for kk = 1:length(nds)
+                    println("node: $(nds[kk]), loc: $(nodes[nds[kk]]), dist: $(distance(nodes,cluster_nodes[end],nds[kk]))")
+                end
+                println("centroid: $c")
+                println("node ID: $(cluster_nodes[end])")
+            end
+        end
+    end
+
+    return cluster_map, cluster_nodes
+end
+
+
+### Replace Nodes in Highways Using Node Remapping
+function replaceHighwayNodes!(highways::Dict{Int,Highway}, node_map::Dict{Int,Int})
+    for (key,hwy) in highways
+        for k = 1:length(hwy.nodes)
+            if haskey(node_map,hwy.nodes[k])
+                hwy.nodes[k] = node_map[hwy.nodes[k]]
+            end
+        end
+    end
+    return nothing
+end
+
+

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -82,3 +82,30 @@ function addNewNode{T<:Union(LLA,ENU)}(nodes::Dict{Int,T}, loc::T)
     msg = "Unable to add new node to map, $(typemax(Int)) nodes is the current limit."
     throw(OverflowError(msg))
 end
+
+### Compute centroid of list of nodes ###
+function centroid{T<:Union(LLA,ENU)}(nodes::Dict{Int,T}, node_list::Vector{Int})
+    sum_1 = 0
+    sum_2 = 0
+    sum_3 = 0
+
+    for k = 1:length(node_list)
+        if typeof(nodes) == Dict{Int,LLA}
+            sum_1 += nodes[node_list[k]].lat
+            sum_2 += nodes[node_list[k]].lon
+            sum_3 += nodes[node_list[k]].alt
+        else
+            sum_1 += nodes[node_list[k]].east
+            sum_2 += nodes[node_list[k]].north
+            sum_3 += nodes[node_list[k]].up
+        end
+    end
+
+    if typeof(nodes) == Dict{Int,LLA}
+        return LLA(sum_1/length(node_list),sum_2/length(node_list),sum_3/length(node_list))
+    else
+        return ENU(sum_1/length(node_list),sum_2/length(node_list),sum_3/length(node_list))
+    end
+end
+
+

--- a/src/parseMap.jl
+++ b/src/parseMap.jl
@@ -9,12 +9,12 @@ type OSMattributes
     visible::Bool
     lanes::Int
 
-    name::String
-    class::String
-    detail::String
-    cycleway::String
-    sidewalk::String
-    bicycle::String
+    name::UTF8String
+    class::UTF8String
+    detail::UTF8String
+    cycleway::UTF8String
+    sidewalk::UTF8String
+    bicycle::UTF8String
 
     # XML elements
     element::Symbol # :None, :Node, :Way, :Tag[, :Relation]

--- a/src/parseMap.jl
+++ b/src/parseMap.jl
@@ -9,12 +9,12 @@ type OSMattributes
     visible::Bool
     lanes::Int
 
-    name::UTF8String
-    class::UTF8String
-    detail::UTF8String
-    cycleway::UTF8String
-    sidewalk::UTF8String
-    bicycle::UTF8String
+    name::String
+    class::String
+    detail::String
+    cycleway::String
+    sidewalk::String
+    bicycle::String
 
     # XML elements
     element::Symbol # :None, :Node, :Way, :Tag[, :Relation]

--- a/src/types.jl
+++ b/src/types.jl
@@ -36,9 +36,13 @@ type Building
 end
 
 type Intersection
-    highways::Set{Int} # Set of highway IDs
+    highways::Set{Int}  # Set of highway IDs
 end
 Intersection() = Intersection(Set{Int}())
+
+type HighwayCluster # Multiple highways representing a single "street" with a common name
+    highways::Set{Int}
+end
 
 type Bounds{T}
     min_y::Float64

--- a/src/types.jl
+++ b/src/types.jl
@@ -40,7 +40,7 @@ type Intersection
 end
 Intersection() = Intersection(Set{Int}())
 
-type HighwayCluster # Multiple highways representing a single "street" with a common name
+type HighwaySet # Multiple highways representing a single "street" with a common name
     highways::Set{Int}
 end
 

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -1,0 +1,36 @@
+# Test intersection detection and clustering
+
+module TestIntersections
+
+using OpenStreetMap
+using Base.Test
+using Compat
+
+import OpenStreetMap: Bounds, centerBounds
+
+MAP_FILENAME = "tech_square.osm"
+
+bounds = Bounds(42.3637, 42.3655, -71.0919, -71.0893)
+
+bounds_ENU = lla2enu(bounds)
+
+nodesLLA, hwys, builds, feats = getOSMData(MAP_FILENAME)
+nodes = lla2enu(nodesLLA,centerBounds(bounds))
+
+# Find intersections in map
+intersections = findIntersections(hwys)
+@test length(intersections) == 91
+
+# Find Highway Sets
+highway_sets = findHighwaySets(hwys)
+@test length(highway_sets) == 4
+
+# Cluster intersections
+intersection_cluster_mapping, intersection_cluster_nodes = findIntersectionClusters(nodes,intersections,highway_sets,max_dist=15)
+replaceHighwayNodes!(hwys,intersection_cluster_mapping)
+intersections_clustered = findIntersections(hwys)
+@test length(intersections_clustered) == 82
+
+end # module TestIntersections
+
+

--- a/test/intersections.jl
+++ b/test/intersections.jl
@@ -26,10 +26,19 @@ highway_sets = findHighwaySets(hwys)
 @test length(highway_sets) == 4
 
 # Cluster intersections
-intersection_cluster_mapping, intersection_cluster_nodes = findIntersectionClusters(nodes,intersections,highway_sets,max_dist=15)
+intersection_cluster_mapping = findIntersectionClusters(nodes,intersections,highway_sets,max_dist=15)
+intersection_clusters = unique(collect(values(intersection_cluster_mapping)))
+@test sort!(intersection_clusters) == [1,2,3,4,5]
+@test length(intersection_clusters) == 5
+
+# Replace Nodes in Highways
 replaceHighwayNodes!(hwys,intersection_cluster_mapping)
 intersections_clustered = findIntersections(hwys)
 @test length(intersections_clustered) == 82
+
+# Check how many semi-redundant intersections we were able to remove
+removed = length(intersections) - length(intersections_clustered)
+@test removed == 9
 
 end # module TestIntersections
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ tests = [
     "crop_map",
     "classes",
     "coordinates",
+    "intersections",
     "routes",
     "plots" ]
 


### PR DESCRIPTION
This code addition (no changes to existing functions were needed) allows clustering of intersection nodes into a single node. This is helpful in the case of boulevards and divided highways crossing one another and inducing 3+ intersections, rather than a single highway intersection. This allows you to get a better estimate of how many highway intersections are present in a region, because the divided highways will not inflate the count.

There is also a function included to replace all clustered intersections' node IDs in the highway list, so that the highways all pass through a single point. This might speed up routing a little bit in some cases, and also enables findIntersections() to be run again on the new set of highways to get the more accurate count.

I also added tests and documentation for the features.

Closes Issue #31. 

