### PR TITLE
Fix distance for empty routes

### DIFF
--- a/src/routing.jl
+++ b/src/routing.jl
@@ -152,6 +152,10 @@ end
 
 ### Compute the distance of a route ###
 function Geodesy.distance{T<:Union(ENU,ECEF)}(nodes::Dict{Int,T}, route::Vector{Int})
+    if length(route) == 0
+        return Inf
+    end
+
     dist = 0.0
     prev_point = nodes[route[1]]
     for i = 2:length(route)

--- a/test/routes.jl
+++ b/test/routes.jl
@@ -56,6 +56,9 @@ fastest_distance = distance(nodesENU, fastest_route)
 @test fastest_route[20] == 2472339219
 @test fastest_route[end] == node1
 
+# Empty route
+@test distance(nodesENU, Int[]) == Inf
+
 # Get route edge list
 shortest_edges = routeEdges(network, shortest_route)
 @test length(shortest_edges) == 22


### PR DESCRIPTION
`distance` used to return `0.0` for empty routes (what the route funcitons return when they can't find any route), but I accidentally made it an error during the switch to use `Geodesy.jl`.

I've got it set to `Inf`, because it matches what the route functions return for distance/time, but I'd be happy to switch it back to `0.0` if that's preferable.