### PR TITLE
Fixed typographical error, changed accomodations to accommodations in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This package provides basic functionality for parsing, viewing, and working with
 * Filter data by various classes:
   * Ways suitable for driving, walking, or cycling
   * Freeways, major city streets, residential streets, etc.
-  * Accomodations, shops, industry, etc.
+  * Accommodations, shops, industry, etc.
 * Draw detailed maps using Julia's [Winston](https://github.com/nolta/Winston.jl) graphics package
   with a variety of options
 * Compute shortest or fastest driving, cycling, and walking routes using Julia's Graphs package


### PR DESCRIPTION
@tedsteiner, I've corrected a typographical error in the documentation of the [OpenStreetMap.jl](https://github.com/tedsteiner/OpenStreetMap.jl) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.