### PR TITLE
Add silent julia nightly runs to Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,12 @@ os:
   - osx
   - linux
 julia:
-  - 0.4
   - 0.3
+  - 0.4
+  - nightly
+matrix:
+  allow_failures:
+    - julia: nightly
 sudo: required
 notifications:
   email: false


### PR DESCRIPTION
A neat trick I saw over at HypothesisTests.jl -- build still nominally passes if a 'nightly' build fails. CI will take longer, but it might be worth it to make it easier to keep ahead of the game.